### PR TITLE
修正错误的链接，test.cust和jwgls1。课表已经可以正常获取

### DIFF
--- a/lib/service/jw_service.dart
+++ b/lib/service/jw_service.dart
@@ -13,8 +13,8 @@ import 'package:custed2/service/mysso_service.dart';
 import 'package:custed2/service/wrdvpn_based_service.dart';
 
 class JwService extends WrdvpnBasedService {
-  static const baseUrl = 'https://jwgls1.cust.edu.cn';
-  
+  static const baseUrl = 'https://jwgl.cust.edu.cn';
+
   final MyssoService _mysso = locator<MyssoService>();
 
   @override
@@ -107,42 +107,41 @@ class JwService extends WrdvpnBasedService {
     final parsedResponse = JwResponse.fromJson(json.decode(response.body));
     final resp = await xRequest(
       'POST',
-      '$baseUrl/api/CommonApi/GetFileContentById'
-          .toUri(),
+      '$baseUrl/api/CommonApi/GetFileContentById'.toUri(),
       body: {
-        'param' : base64Encode(utf8.encode('%7B%22Id%22%3A%22'
+        'param': base64Encode(utf8.encode('%7B%22Id%22%3A%22'
             '${parsedResponse.data['StudentDto']['ZPID']}%22%7D')),
-        '__log' : {
-          'Context' : '查询',
-          'Logtype' : 6,
-          'MenuID' : '4443798E-EB6E-4D88-BFBD-BB0A76FF6BD5'
+        '__log': {
+          'Context': '查询',
+          'Logtype': 6,
+          'MenuID': '4443798E-EB6E-4D88-BFBD-BB0A76FF6BD5'
         },
-        '__permission' : {
-          'MenuID' : '4443798E-EB6E-4D88-BFBD-BB0A76FF6BD5',
-          'Operation' : 0
+        '__permission': {
+          'MenuID': '4443798E-EB6E-4D88-BFBD-BB0A76FF6BD5',
+          'Operation': 0
         }
       },
       headers: {'content-type': 'application/json'},
     );
 
-    Map<String,dynamic> jsonData = json.decode(resp.body);
+    Map<String, dynamic> jsonData = json.decode(resp.body);
     return jsonData['data']['ZZCLBlob']['Base64String'];
   }
 
-  Future<String> getExam() async{
+  Future<String> getExam() async {
     final resp = await xRequest(
       'POST',
       '$baseUrl/api/ClientStudent/Home/StudentHomeApi/QueryStudentExamAssign',
       body: {
-        'param':'JTdCJTdE',
-        '__permission':{
-          'MenuID':'00000000-0000-0000-0000-000000000000',
-          "Operation":0
+        'param': 'JTdCJTdE',
+        '__permission': {
+          'MenuID': '00000000-0000-0000-0000-000000000000',
+          "Operation": 0
         },
-        "__log":{
-          "MenuID":"00000000-0000-0000-0000-000000000000",
-          "Logtype":6,
-          "Context":"查询"
+        "__log": {
+          "MenuID": "00000000-0000-0000-0000-000000000000",
+          "Logtype": 6,
+          "Context": "查询"
         }
       },
       headers: {'content-type': 'application/json'},

--- a/lib/service/mysso_service.dart
+++ b/lib/service/mysso_service.dart
@@ -29,7 +29,7 @@ class MyssoService extends CatService {
   Future<CatLoginResult<String>> login({bool force = false}) async {
     if (force) clearCookieFor(baseUrl.toUri());
 
-    final loginService = 'http://portal.cust.edu.cn/custp2/shiro-cas';
+    final loginService = 'https://portal.cust.edu.cn/custp/shiro-cas';
     final loginUrlWithService = '$loginUrl?service=$loginService';
 
     // final loginPage = await getFrontPage(loginUrlWithService);
@@ -132,7 +132,7 @@ class MyssoService extends CatService {
   }
 
   Future<String> getTicketForPortal() =>
-      getTicket('http://portal.cust.edu.cn/custp/shiro-cas');
+      getTicket('https://portal.cust.edu.cn/custp/shiro-cas');
 
   Future<String> getTicketForWebvpn() =>
       getTicket('https://webvpn.cust.edu.cn/auth/cas_validate?entry_id=1');
@@ -141,7 +141,7 @@ class MyssoService extends CatService {
       getTicket('http://wwwn.cust.edu.cn/wengine-auth/login?cas_login=true');
 
   Future<String> getTicketForJw() =>
-      getTicket('https://jwgls1.cust.edu.cn/welcome');
+      getTicket('https://jwgl.cust.edu.cn/welcome');
 
   Future<String> getTicketForIecard() =>
       getTicket('http://iecard.cust.edu.cn:8080/ias/prelogin?sysid=FWDT');

--- a/lib/ui/pages/login_page.dart
+++ b/lib/ui/pages/login_page.dart
@@ -64,7 +64,7 @@ class _LoginPageState extends State<LoginPage> {
           this.controller = controller;
           await CookieManager().clearCookies();
           controller.loadUrl(
-            'https://mysso.cust.edu.cn/cas/login?service=http://test.cust.edu.cn/custp2/shiro-cas',
+            'https://mysso.cust.edu.cn/cas/login?service=https://portal.cust.edu.cn/custp/shiro-cas',
           );
         },
         onPageStarted: (url) {
@@ -87,8 +87,7 @@ class _LoginPageState extends State<LoginPage> {
         navigationDelegate: (request) async {
           print('Redirect: ${request.url}');
 
-          if (request.url.contains('custp2') ||
-              request.url.contains('test.cust.edu.cn') ||
+          if (request.url.contains('custp') ||
               request.url.contains('portal.cust.edu.cn')) {
             Future.delayed(200.ms, _loginSuccessCallback);
             return NavigationDecision.prevent;

--- a/lib/ui/webview/plugin_portal.dart
+++ b/lib/ui/webview/plugin_portal.dart
@@ -12,6 +12,9 @@ class PluginForPortal extends Webview2Plugin {
   @override
   bool shouldActivate(Uri uri) {
     return uri.path.startsWith('/custp2/index');
+    // 不知道这个判断干什么用的，所以没改，但是现在test.cust.edu.cn/custp2已经不用了，
+    // 内网外网统一用https://portal.cust.edu.cn或https://portal.cust.edu.cn/custp/index,
+    // 另外，portal和其他使用cas的服务推荐使用https协议，不然cas传参可能会出问题
   }
 
   @override


### PR DESCRIPTION
test.cust.edu.cn/custp2/index统一改为
https://portal.cust.edu.cn/custp/index
前者是门户测试服务器，现已停用。

教务相关链接三级域名由jwgls1改为jwgl，
前者为本科生教务的一台后端机，其课表相关api已损坏
后者为本科生教务反向代理入口，会随机分配后端机，提高获取课表成功率。目前教务后端机有三台，s1, s2, s3，
以及不参与反代的教师专用机，三级域名为jwgljs

以上

Signed-off-by: Wonder2018 <49940418+Wonder2018@users.noreply.github.com>